### PR TITLE
Metadatabug/odim 3718

### DIFF
--- a/svc-api/handle/handlers.go
+++ b/svc-api/handle/handlers.go
@@ -17,6 +17,7 @@ package handle
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -543,10 +544,11 @@ func GetMetadata(ctx iris.Context) {
 		"Allow":             "GET",
 		"Cache-Control":     "no-cache",
 		"Transfer-Encoding": "chunked",
+		"Content-type":      "application/xml; charset=utf-8",
 	}
-
+	xmlData, _ := xml.Marshal(Metadata)
 	SetResponseHeaders(ctx, headers)
-	ctx.XML(Metadata)
+	ctx.Write(xmlData)
 
 }
 


### PR DESCRIPTION
Updated the ODIM/svc-api/handle/handlers.go with the below lines to change the Content-Type: application/xml.

var headers = map[string]string

{ "Allow": "GET", "Cache-Control": "no-cache", "Transfer-Encoding": "chunked", "Content-type": "application/xml; charset=utf-8", }
xmlData,_:=xml.Marshal(Metadata)
SetResponseHeaders(ctx, headers)
ctx.Write(xmlData)